### PR TITLE
bugfix #42

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -100,7 +100,10 @@ def update_wishlist(wishlist_id):
         )
 
     # Update from the json in the body of the request
-    wishlist.deserialize(request.get_json())
+    original_data = wishlist.serialize()
+    data = request.get_json()
+    data["created_at"] = original_data["created_at"]
+    wishlist.deserialize(data)
     wishlist.id = wishlist_id
     wishlist.update()
 
@@ -142,6 +145,7 @@ def check_content_type(content_type):
     abort(
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, f"Content-Type must be {content_type}"
     )
+
 
 # ---------------------------------------------------------------------
 #                I T E M   M E T H O D S
@@ -191,6 +195,7 @@ def create_wishlist_item(wishlist_id):
 ######################################################################
 # RETRIEVE AN ITEM FROM WISHLIST
 ######################################################################
+
 
 @app.route("/wishlists/<int:wishlist_id>/items/<int:id>", methods=["GET"])
 def get_addresses(wishlist_id, id):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -139,6 +139,7 @@ class WishlistService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         updated_wishlist = resp.get_json()
         self.assertEqual(updated_wishlist["name"], "Birthday wishlist")
+        self.assertEqual(updated_wishlist["created_at"], new_wishlist["created_at"])
 
     def test_update_nonexisting_wishlist(self):
         """It should Not be able to Update a non-existing Wishlist"""


### PR DESCRIPTION
This PR fixes the bug  #42 
 - `created_at` value of wishlist database was being updated on PUT calls.
 - This PR fixes it so that it now remains unchanged