### PR TITLE
Refactor: Rename WishListItem to Wishlistitem and updated id naming convention

### DIFF
--- a/service/models/__init__.py
+++ b/service/models/__init__.py
@@ -6,4 +6,4 @@ All of the models are stored in this package
 
 from .persistent_base import db, DataValidationError
 from .wishlist import Wishlist
-from .wishlist_item import WishListItem
+from .wishlist_item import WishlistItem

--- a/service/models/wishlist.py
+++ b/service/models/wishlist.py
@@ -22,7 +22,7 @@ Persistent Base class for Wishlist database CRUD functions
 
 import logging
 from .persistent_base import db, PersistentBase, DataValidationError
-from .wishlist_item import WishListItem
+from .wishlist_item import WishlistItem
 
 logger = logging.getLogger("flask.app")
 
@@ -58,7 +58,7 @@ class Wishlist(db.Model, PersistentBase):
     )
     is_public = db.Column(db.Boolean, default=False)
     wishlist_items = db.relationship(
-        "WishListItem", backref="wishlist", passive_deletes=True
+        "WishlistItem", backref="wishlist", passive_deletes=True
     )
 
     def __repr__(self):
@@ -104,7 +104,7 @@ class Wishlist(db.Model, PersistentBase):
             # handle inner list of addresses
             wishlist_items_items = data.get("wishlist_items", [])
             for json_wishlists_items in wishlist_items_items:
-                wishlist_item = WishListItem()
+                wishlist_item = WishlistItem()
                 wishlist_item.deserialize(json_wishlists_items)
                 self.wishlist_items.append(wishlist_item)
         except KeyError as error:

--- a/service/models/wishlist_item.py
+++ b/service/models/wishlist_item.py
@@ -27,7 +27,7 @@ logger = logging.getLogger("flask.app")
 ######################################################################
 #  W I S H L I S T  I T E M   M O D E L
 ######################################################################
-class WishListItem(db.Model, PersistentBase):
+class WishlistItem(db.Model, PersistentBase):
     """
     Class that represents a wishlist item
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -25,7 +25,7 @@ and Delete wishlist and wishlist items from the account in a e-commerce website.
 
 from flask import jsonify, request, abort, url_for
 from flask import current_app as app  # Import Flask application
-from service.models import Wishlist, WishListItem
+from service.models import Wishlist, WishlistItem
 from service.common import status  # HTTP Status Codes
 
 
@@ -117,17 +117,17 @@ def update_wishlist(wishlist_id):
 ######################################################################
 # DELETE A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:id>", methods=["DELETE"])
+@app.route("/wishlists/<int:wishlist_id>", methods=["DELETE"])
 # pylint: disable=redefined-builtin
-def delete_wishlist(id):
+def delete_wishlist(wishlist_id):
     """
     Delete a wishlist
     This endpoint will delete a Wishlist based on the id specified in the path
     """
-    app.logger.info("Request to delete account with id: %s", id)
+    app.logger.info("Request to delete account with id: %s", wishlist_id)
 
     # Retrieve the wishlist from DB and delete it
-    wishlist_to_delete = Wishlist.find(id)
+    wishlist_to_delete = Wishlist.find(wishlist_id)
     if wishlist_to_delete:
         wishlist_to_delete.delete()
 
@@ -187,7 +187,7 @@ def create_wishlist_item(wishlist_id):
         )
 
     # Create an address from the json data
-    item = WishListItem()
+    item = WishlistItem()
     item_data = request.get_json()
     item_data["wishlist_id"] = wishlist_id
     item.deserialize(item_data)
@@ -232,14 +232,15 @@ def list_wishlist_items(wishlist_id):
 ######################################################################
 
 
-@app.route("/wishlists/<int:wishlist_id>/items/<int:id>", methods=["GET"])
+@app.route("/wishlists/<int:wishlist_id>/items/<int:wishlistitem_id>", methods=["GET"])
 # pylint: disable=redefined-builtin
-def get_wishlist_item(wishlist_id, id):
+def get_wishlist_item(wishlist_id, wishlistitem_id):
     """
     This endpoint returns just an item
     """
     app.logger.info(
-        "Request to retrieve item %s for Wishlist id: %s", (id, wishlist_id)
+        "Request to retrieve item %s for Wishlist id: %s",
+        (wishlistitem_id, wishlist_id),
     )
 
     # See if the wishlist exists and abort if it doesn't
@@ -251,18 +252,18 @@ def get_wishlist_item(wishlist_id, id):
         )
 
     # See if the item exists and abort if it doesn't
-    item = WishListItem.find(id)
+    item = WishlistItem.find(wishlistitem_id)
     if not item:
         abort(
             status.HTTP_404_NOT_FOUND,
-            f"Item with id='{id}' could not be found.",
+            f"Item with id='{wishlistitem_id}' could not be found.",
         )
 
     # An extra check to verify that item belongs to wishlist id provided
     if wishlist_id != item.wishlist_id:
         abort(
             status.HTTP_404_NOT_FOUND,
-            f"Item with id='{id}' could not be found inside wishlist with id='{wishlist_id}",
+            f"Item with id='{wishlistitem_id}' could not be found inside wishlist with id='{wishlist_id}",
         )
 
     return jsonify(item.serialize()), status.HTTP_200_OK
@@ -293,20 +294,23 @@ def get_wishlists(wishlist_id):
 ######################################################################
 
 
-@app.route("/wishlists/<int:wishlist_id>/items/<int:id>", methods=["DELETE"])
+@app.route(
+    "/wishlists/<int:wishlist_id>/items/<int:wishlistitem_id>", methods=["DELETE"]
+)
 # pylint: disable=redefined-builtin
-def delete_wishlist_item(wishlist_id, id):
+def delete_wishlist_item(wishlist_id, wishlistitem_id):
     """
     Delete a wishlist item
 
     This endpoint will delete a wishlist item based the id specified in the path
     """
     app.logger.info(
-        "Request to delete wishlist item  %s for wishlist  id: %s", (id, wishlist_id)
+        "Request to delete wishlist item  %s for wishlist  id: %s",
+        (wishlistitem_id, wishlist_id),
     )
 
     # See if the wishlist item  exists and delete it if it does
-    wishlist_item = WishListItem.find(id)
+    wishlist_item = WishlistItem.find(wishlistitem_id)
     if wishlist_item:
         wishlist_item.delete()
 
@@ -318,15 +322,15 @@ def delete_wishlist_item(wishlist_id, id):
 ######################################################################
 
 
-@app.route("/wishlists/<int:wishlist_id>/items/<int:item_id>", methods=["PUT"])
-def update_wishlist_items(wishlist_id, item_id):
+@app.route("/wishlists/<int:wishlist_id>/items/<int:wishlistitem_id>", methods=["PUT"])
+def update_wishlist_items(wishlist_id, wishlistitem_id):
     """
     Update a Wishlist Item
     This endpoint will update a wishlist item based the body that is posted
     """
     app.logger.info(
         "Request to update a wishlist item %s for Wishlist id: %s",
-        (item_id, wishlist_id),
+        (wishlistitem_id, wishlist_id),
     )
     check_content_type("application/json")
     wishlist = Wishlist.find(wishlist_id)
@@ -337,11 +341,11 @@ def update_wishlist_items(wishlist_id, item_id):
             f"Wishlist with id '{wishlist_id}' could not be found.",
         )
     # See if the item exists and abort if it doesn't
-    item = WishListItem.find(item_id)
+    item = WishlistItem.find(wishlistitem_id)
     if not item:
         abort(
             status.HTTP_404_NOT_FOUND,
-            f"Item with id '{item_id}' could not be found in the Wishlist with id '{wishlist_id}'.",
+            f"Item with id '{wishlistitem_id}' could not be found in the Wishlist with id '{wishlist_id}'.",
         )
     if wishlist_id != item.wishlist_id:
         abort(
@@ -353,6 +357,6 @@ def update_wishlist_items(wishlist_id, item_id):
     # original_data = item.serialize()
     # data["created_at"] = original_data["created_at"]
     item.deserialize(data)
-    item.id = item_id
+    item.id = wishlistitem_id
     item.update()
     return jsonify(item.serialize()), status.HTTP_200_OK

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,12 +1,13 @@
-'''
+"""
 Factory file to create fake datasets of wishlists and wishlists_items for ease in application testing
-'''
+"""
+
 from datetime import datetime, timezone
 
 from decimal import Decimal
 import factory
 from factory.fuzzy import FuzzyChoice, FuzzyDateTime
-from service.models import Wishlist, WishListItem
+from service.models import Wishlist, WishlistItem
 
 
 class WishlistFactory(factory.Factory):
@@ -37,14 +38,14 @@ class WishlistFactory(factory.Factory):
             self.wishlist_items = extracted
 
 
-class WishListItemFactory(factory.Factory):
+class WishlistItemFactory(factory.Factory):
     """Creates fake wishlist items that you don't have to feed"""
 
     # pylint: disable=too-few-public-methods
     class Meta:
         """Maps factory to wishlist item data model"""
 
-        model = WishListItem
+        model = WishlistItem
 
     id = factory.Sequence(lambda n: n)
     wishlist_id = factory.Faker("random_int", min=1, max=9999)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,8 +8,8 @@ from unittest import TestCase
 from datetime import datetime, timezone, timedelta
 from wsgi import app
 from service.common import status
-from service.models import db, Wishlist, WishListItem
-from .factories import WishlistFactory, WishListItemFactory
+from service.models import db, Wishlist, WishlistItem
+from .factories import WishlistFactory, WishlistItemFactory
 
 # cspell: ignore psycopg testdb
 
@@ -49,7 +49,7 @@ class WishlistService(TestCase):
         """Runs before each test"""
         self.client = app.test_client()
         db.session.query(Wishlist).delete()  # clean up the last tests
-        db.session.query(WishListItem).delete()  # clean up the last tests
+        db.session.query(WishlistItem).delete()  # clean up the last tests
         db.session.commit()
 
     def tearDown(self):
@@ -247,7 +247,7 @@ class WishlistService(TestCase):
     def test_add_item(self):
         """It should Add an item to a wishlist"""
         wishlist = self._create_wishlists(1)[0]
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),
@@ -266,7 +266,7 @@ class WishlistService(TestCase):
     def test_add_items_in_invalid_wishlist(self):
         """It should not be able to add an item in invalid wishlists"""
         wishlist = self._create_wishlists(1)[0]
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         wishlist_id = wishlist.id + 1
         resp = self.client.post(
             f"{BASE_URL}/{wishlist_id}/items",
@@ -279,7 +279,7 @@ class WishlistService(TestCase):
         """It should Get a list of Addresses"""
         # add two addresses to account
         wishlist = self._create_wishlists(1)[0]
-        items_list = WishListItemFactory.create_batch(2)
+        items_list = WishlistItemFactory.create_batch(2)
 
         # Create address 1
         resp = self.client.post(
@@ -303,7 +303,7 @@ class WishlistService(TestCase):
     def test_list_invalid_wishlists_items(self):
         """It should not get a list of items from an invalid wishlists"""
         wishlist = self._create_wishlists(1)[0]
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),
@@ -317,7 +317,7 @@ class WishlistService(TestCase):
     def test_read_item(self):
         """It should read an item from wishlist"""
         wishlist = self._create_wishlists(1)[0]
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),
@@ -348,7 +348,7 @@ class WishlistService(TestCase):
         """It should not be able to read a non-existent item"""
 
         wishlist = self._create_wishlists(1)[0]
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),
@@ -381,7 +381,7 @@ class WishlistService(TestCase):
         wishlist = self._create_wishlists(1)[0]
         wishlist2 = self._create_wishlists(1)[0]
         self.assertNotEqual(wishlist.id, wishlist2.id)
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),
@@ -421,7 +421,7 @@ class WishlistService(TestCase):
         """It should Delete a wishlist item from the wishlist if it exists"""
         # get the id of an wishlist
         wishlist = self._create_wishlists(1)[0]
-        wishlist_item = WishListItemFactory()
+        wishlist_item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=wishlist_item.serialize(),
@@ -449,7 +449,7 @@ class WishlistService(TestCase):
         """It should Update an item on a wishlist"""
         # create a item inside a wishlist
         wishlist = self._create_wishlists(1)[0]
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),
@@ -483,7 +483,7 @@ class WishlistService(TestCase):
         """It should not Update an non-existing item on a wishlist"""
         # create a item and wishlist
         wishlist = self._create_wishlists(1)[0]
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),
@@ -520,7 +520,7 @@ class WishlistService(TestCase):
         wishlist = self._create_wishlists(1)[0]
         wishlist2 = self._create_wishlists(1)[0]
         self.assertNotEqual(wishlist.id, wishlist2.id)
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         resp = self.client.post(
             f"{BASE_URL}/{wishlist.id}/items",
             json=item.serialize(),

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -7,8 +7,8 @@ import logging
 from unittest import TestCase
 from unittest.mock import patch
 from wsgi import app
-from service.models import Wishlist, WishListItem, DataValidationError, db
-from tests.factories import WishlistFactory, WishListItemFactory
+from service.models import Wishlist, WishlistItem, DataValidationError, db
+from tests.factories import WishlistFactory, WishlistItemFactory
 
 # cspell: ignore psycopg testdb, psycopg
 
@@ -41,7 +41,7 @@ class TestWishlist(TestCase):
     def setUp(self):
         """This runs before each test"""
         db.session.query(Wishlist).delete()  # clean up the last tests
-        db.session.query(WishListItem).delete()  # clean up the last tests
+        db.session.query(WishlistItem).delete()  # clean up the last tests
         db.session.commit()
 
     def tearDown(self):
@@ -186,7 +186,7 @@ class TestWishlist(TestCase):
     def test_serialize_a_wishlist(self):
         """It should Serialize a Wishlist with WishlistItem"""
         wishlist = WishlistFactory()
-        item = WishListItemFactory()
+        item = WishlistItemFactory()
         wishlist.wishlist_items.append(item)
         serial_wishlist = wishlist.serialize()
         self.assertEqual(serial_wishlist["id"], wishlist.id)
@@ -213,7 +213,7 @@ class TestWishlist(TestCase):
     def test_deserialize_a_wishlist(self):
         """It should Deserialize a wishlist"""
         wishlist = WishlistFactory()
-        wishlist.wishlist_items.append(WishListItemFactory())
+        wishlist.wishlist_items.append(WishlistItemFactory())
         wishlist.create()
         serial_wishlist = wishlist.serialize()
         new_wishlist = Wishlist()
@@ -239,10 +239,10 @@ class TestWishlist(TestCase):
 
     def test_deserialize_item_key_error(self):
         """It should not Deserialize an item with a KeyError"""
-        item = WishListItem()
+        item = WishlistItem()
         self.assertRaises(DataValidationError, item.deserialize, {})
 
     def test_deserialize_item_type_error(self):
         """It should not Deserialize an item with a TypeError"""
-        item = WishListItem()
+        item = WishlistItem()
         self.assertRaises(DataValidationError, item.deserialize, [])

--- a/tests/test_wishlist_item.py
+++ b/tests/test_wishlist_item.py
@@ -22,8 +22,8 @@ import logging
 import os
 from unittest import TestCase
 from wsgi import app
-from service.models import Wishlist, WishListItem, db, DataValidationError
-from tests.factories import WishListItemFactory, WishlistFactory
+from service.models import Wishlist, WishlistItem, db, DataValidationError
+from tests.factories import WishlistItemFactory, WishlistFactory
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
@@ -33,7 +33,7 @@ DATABASE_URI = os.getenv(
 ######################################################################
 #        W I S H L I S T  I T E M   M O D E L   T E S T   C A S E S
 ######################################################################
-class TestWishListItem(TestCase):
+class TestWishlistItem(TestCase):
     """WishlistItem Model Test Cases"""
 
     # pylint: disable=duplicate-code
@@ -56,7 +56,7 @@ class TestWishListItem(TestCase):
     def setUp(self):
         """This runs before each test"""
         db.session.query(Wishlist).delete()  # clean up the last tests
-        db.session.query(WishListItem).delete()  # clean up the last tests
+        db.session.query(WishlistItem).delete()  # clean up the last tests
         db.session.commit()
 
     # pylint: disable=duplicate-code
@@ -70,7 +70,7 @@ class TestWishListItem(TestCase):
 
     def test_serialize_an_wishlist_item(self):
         """It should serialize an wishlist item"""
-        wishlist_item = WishListItemFactory()
+        wishlist_item = WishlistItemFactory()
         serial_wishlist_item = wishlist_item.serialize()
         self.assertEqual(serial_wishlist_item["id"], wishlist_item.id)
         self.assertEqual(serial_wishlist_item["wishlist_id"], wishlist_item.wishlist_id)
@@ -95,9 +95,9 @@ class TestWishListItem(TestCase):
 
     def test_deserialize_a_wishlist_item(self):
         """It should deserialize a wishlist item"""
-        wishlist_item = WishListItemFactory()
+        wishlist_item = WishlistItemFactory()
         wishlist_item.create()
-        new_wishlist_item = WishListItem()
+        new_wishlist_item = WishlistItem()
         new_wishlist_item.deserialize(wishlist_item.serialize())
         self.assertEqual(new_wishlist_item.wishlist_id, wishlist_item.wishlist_id)
         self.assertEqual(new_wishlist_item.product_id, wishlist_item.product_id)
@@ -112,7 +112,7 @@ class TestWishListItem(TestCase):
         wishlists = Wishlist.all()
         self.assertEqual(wishlists, [])
         wishlist = WishlistFactory()
-        item = WishListItemFactory(wishlist=wishlist)
+        item = WishlistItemFactory(wishlist=wishlist)
         wishlist.wishlist_items.append(item)
         wishlist.create()
         # Assert that it was assigned an id and shows up in the database
@@ -123,7 +123,7 @@ class TestWishListItem(TestCase):
         new_wishlist = Wishlist.find(wishlist.id)
         self.assertEqual(new_wishlist.wishlist_items[0].product_name, item.product_name)
 
-        item2 = WishListItemFactory(wishlist=wishlist)
+        item2 = WishlistItemFactory(wishlist=wishlist)
         wishlist.wishlist_items.append(item2)
         wishlist.update()
 
@@ -138,7 +138,7 @@ class TestWishListItem(TestCase):
         wishlists = Wishlist.all()
         self.assertEqual(wishlists, [])
         wishlist = WishlistFactory()
-        item = WishListItemFactory(wishlist=wishlist)
+        item = WishlistItemFactory(wishlist=wishlist)
         wishlist.wishlist_items.append(item)
         wishlist.create()
         # Assert that it was assigned an id and shows up in the database
@@ -146,22 +146,22 @@ class TestWishListItem(TestCase):
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 1)
 
-        wishlist_items = WishListItem.all()
+        wishlist_items = WishlistItem.all()
         self.assertEqual(len(wishlist_items), 1)
 
-        wishlist_item = WishListItem.find(wishlist.wishlist_items[0].id)
+        wishlist_item = WishlistItem.find(wishlist.wishlist_items[0].id)
         wishlist_item.delete()
-        wishlist_items = WishListItem.all()
+        wishlist_items = WishlistItem.all()
         self.assertEqual(len(wishlist_items), 0)
 
     def test_deserialize_wishlist_item_key_error(self):
         """It should not Deserialize an item with a KeyError"""
-        item = WishListItem()
+        item = WishlistItem()
         self.assertRaises(DataValidationError, item.deserialize, {})
 
     def test_deserialize_wishlist_item_type_error(self):
         """It should not Deserialize an item with a TypeError"""
-        item = WishListItem()
+        item = WishlistItem()
         self.assertRaises(DataValidationError, item.deserialize, [])
 
     def test_update_wishlist_item(self):
@@ -169,7 +169,7 @@ class TestWishListItem(TestCase):
         wishlists = Wishlist.all()
         self.assertEqual(wishlists, [])
         wishlist = WishlistFactory()
-        item = WishListItemFactory(wishlist=wishlist)
+        item = WishlistItemFactory(wishlist=wishlist)
         wishlist.create()
         # Assert that it was assigned an id and shows up in the database
         self.assertIsNotNone(wishlist.id)


### PR DESCRIPTION
This PR implements the following updates:
* Changed `WishListItem` to `WishlistItem` throughout the codebase.
* Updated ID naming convention to `wishlist_id` and `wishlistitem_id` depending on the case.